### PR TITLE
Update User Agent

### DIFF
--- a/src/lib/RESTManager.ts
+++ b/src/lib/RESTManager.ts
@@ -16,6 +16,7 @@ import type { Request, RouteIdentifier, REST } from './REST';
 const agent = new Agent({ keepAlive: true });
 
 export interface RESTOptions {
+	userAgentAppendix: string;
 	offset: number;
 	retries: number;
 	timeout: number;
@@ -128,7 +129,7 @@ export class RESTManager {
 
 		// Assign the basic request headers
 		const headers: Headers = {
-			'User-Agent': UserAgent,
+			'User-Agent': `${UserAgent} ${this.options.userAgentAppendix}`,
 			'X-RateLimit-Precision': 'millisecond'
 		};
 

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -5,6 +5,7 @@ import type { RESTOptions } from '../lib/RESTManager';
 export const UserAgent = `DiscordBot (${Package.repository.url}, ${Package.version})`;
 
 export const RestOptionsDefaults: Required<RESTOptions> = {
+	userAgentAppendix: `Node.js/${process.version}`,
 	offset: 100,
 	retries: 1,
 	timeout: 15000,

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -2,7 +2,7 @@ import * as Package from '../../package.json';
 
 import type { RESTOptions } from '../lib/RESTManager';
 
-export const UserAgent = `DiscordBot (@klasa/rest, ${Package.version}) Node.js/${process.version}`;
+export const UserAgent = `DiscordBot (${Package.repository.url}, ${Package.version})`;
 
 export const RestOptionsDefaults: Required<RESTOptions> = {
 	offset: 100,


### PR DESCRIPTION
As discussed in the Discord server, this PR adds a userAgentAppendix option and updates the UserAgent to conform with what Discord expects.

I've put the Node.js version as the default setting for this, so the only default behavior that would be different after merging would be the package URL in place of `@klasa/rest`.