### PR TITLE
refactor: CDN types and Spread Order

### DIFF
--- a/src/lib/REST.ts
+++ b/src/lib/REST.ts
@@ -65,7 +65,7 @@ export class REST extends EventEmitter {
 	 * @param options The request options
 	 */
 	public get(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
-		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'get'), { method: 'get', endpoint, ...options });
+		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'get'), { ...options, method: 'get', endpoint });
 	}
 
 	/**
@@ -74,7 +74,7 @@ export class REST extends EventEmitter {
 	 * @param options The request options
 	 */
 	public delete(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
-		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'delete'), { method: 'delete', endpoint, ...options });
+		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'delete'), { ...options, method: 'delete', endpoint });
 	}
 
 	/**
@@ -83,7 +83,7 @@ export class REST extends EventEmitter {
 	 * @param options The request options
 	 */
 	public patch(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
-		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'patch'), { method: 'patch', endpoint, ...options });
+		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'patch'), { ...options, method: 'patch', endpoint });
 	}
 
 	/**
@@ -92,7 +92,7 @@ export class REST extends EventEmitter {
 	 * @param options The request options
 	 */
 	public put(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
-		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'put'), { method: 'put', endpoint, ...options });
+		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'put'), { ...options, method: 'put', endpoint });
 	}
 
 	/**
@@ -101,7 +101,7 @@ export class REST extends EventEmitter {
 	 * @param options The request options
 	 */
 	public post(endpoint: string, options: RequestOptions = {}): Promise<unknown> {
-		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'post'), { method: 'post', endpoint, ...options });
+		return this.manager.queueRequest(REST.generateRouteIdentifiers(endpoint, 'post'), { ...options, method: 'post', endpoint });
 	}
 
 	/**

--- a/src/types/InternalREST.ts
+++ b/src/types/InternalREST.ts
@@ -6,10 +6,11 @@ export const enum RESTManagerEvents {
 }
 
 export type ImageExtension = 'png' | 'gif' | 'webp' | 'jpg' | 'jpeg';
+export type ImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
 export type EmojiExtension = 'png' | 'gif';
 
 export interface ImageURLOptions {
 	extension?: ImageExtension;
-	size?: 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
+	size?: ImageSize;
 	dynamic?: boolean;
 }

--- a/src/types/InternalREST.ts
+++ b/src/types/InternalREST.ts
@@ -9,7 +9,7 @@ export type ImageExtension = 'png' | 'gif' | 'webp' | 'jpg' | 'jpeg';
 export type EmojiExtension = 'png' | 'gif';
 
 export interface ImageURLOptions {
-	extension?: string;
-	size?: number;
+	extension?: ImageExtension;
+	size?: 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
 	dynamic?: boolean;
 }

--- a/test/CDN.ts
+++ b/test/CDN.ts
@@ -66,10 +66,14 @@ ava('userAvatar:dynamic-not-animated', (test): void => {
 });
 
 ava('makeURL:throws on invalid size', (test): void => {
+	// eslint-ignore-next-line ban-ts-comments
+	// @ts-expect-error
 	test.throws(() => cdn.userAvatar(id, animatedHash, { size: 5 }), { instanceOf: RangeError });
 });
 
 ava('makeURL:throws on invalid extension', (test): void => {
+	// eslint-ignore-next-line ban-ts-comments
+	// @ts-expect-error
 	test.throws(() => cdn.userAvatar(id, animatedHash, { extension: 'tif' }), { instanceOf: RangeError });
 });
 


### PR DESCRIPTION
This PR makes types on CDN stricter as well as provides autocomplete features. On another aspect, it also moves the ...options first so options can not override other props.